### PR TITLE
use keydown to close settings

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -282,7 +282,7 @@
 </main>
 <SettingsOverlay visible="{settingsPanelVisible}" />
 
-<svelte:window on:keyup="{handleKeyUp}" />
+<svelte:window on:keydown="{handleKeyDown}" />
 
 <script>
 	/* © 2019 int3ractive.com
@@ -311,7 +311,7 @@
 		// console.log(settingsPanelVisible);
 	}
 
-	function handleKeyUp(event) {
+	function handleKeyDown(event) {
 		// console.log(event.key);
 		if (settingsPanelVisible && event.key === 'Escape') {
 			settingsPanelVisible = false;


### PR DESCRIPTION
I don't know why I keep noticing this but a key up should never close something like this. Because when I select text if I keyup outside the modal I close the whole thing when I was just trying to select my text, it just happened so I ended up here. The action to close the modal is to click on the overlay... so why not use the event that works on click?